### PR TITLE
Add "vectorDrawables.useSupportLibrary = true" to defaultConfig fixes #7

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,7 @@ android {
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {


### PR DESCRIPTION
Resolves build error "references to other resources are not supported by build-time PNG generation" happening in Android Studio 3